### PR TITLE
refactor: Adds rel=me to Mastodon link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,7 +22,7 @@ pygmentsStyle = "monokai"
         onload="renderMathInElement(document.body);"></script>
   """
   socialIcons = [
-    {name = "mastodon", url = "https://mastodon.online/@camdecoster"},
+    {name = "mastodon", rel = "me", url = "https://mastodon.online/@camdecoster"},
     {name = "twitter", url = "https://twitter.com/camdecoster"},
     {name = "linkedin", url = "https://www.linkedin.com/in/camerondecoster"},
     {name = "github", url = "https://github.com/camdecoster"}


### PR DESCRIPTION
This is necessary to enable profile verification on Mastodon.